### PR TITLE
Updating gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,10 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+# Module Repo
+/bin/
+/target/
+**/cert
+**/cred
+src/main/java/programmingtheiot/gda/.DS_Store


### PR DESCRIPTION
Updating gitignore to add folders that are present in the Module repo by default, which includes folder that updates after running Maven Tests.